### PR TITLE
Fixed save in microsoft edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install @brightspace-ui-labs/edit-in-place
 - `placeholder`String, default: `'Enter a value'`): placeholder text of the input. If `value` is blank, this appears in italics as the label. `placeholder` must not be blank.
 - `size`(Number): length of the input
 - `maxlength`(Number): imposes an upper character limit
-- `readonly`(Boolean): Prevents the control from entering edit mode if true.
+- `readonly`(Boolean): The label will behave like a simple text element if true.
 
 **Events:**
 

--- a/demo/d2l-labs-edit-in-place.html
+++ b/demo/d2l-labs-edit-in-place.html
@@ -11,9 +11,9 @@
         <script type="module" src="../../../@brightspace-ui/core/components/typography/typography.js"></script>
 
         <script type="module">
-                import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
-                import '../src/d2l-labs-edit-in-place.js';
-            </script>
+            import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+            import '../src/d2l-labs-edit-in-place.js';
+        </script>
 
         <script type="module">
             const $_documentContainer = document.createElement('template');
@@ -58,5 +58,4 @@
 		    </div>
         </d2l-demo-page>
     </body>
-
 </html>

--- a/src/d2l-labs-edit-in-place.js
+++ b/src/d2l-labs-edit-in-place.js
@@ -163,7 +163,6 @@ class EditInPlace extends LocalizeMixin(LitElement) {
 			'change',
 			{bubbles: true, composed: false}
 		));
-
 	}
 
 	cancelValueChange() {

--- a/src/d2l-labs-edit-in-place.js
+++ b/src/d2l-labs-edit-in-place.js
@@ -148,9 +148,9 @@ class EditInPlace extends LocalizeMixin(LitElement) {
 	}
 
 	saveValueChange_Keydown(e) {
+		this.updateInputTextValue(e);
 		if (e.keyCode === 13)
 		{
-			this.updateInputTextValue(e);
 			this.saveValueChange();
 		}
 	}


### PR DESCRIPTION
Save didn't work, due to the change event not firing on the input when the user presses the save button.
Now the input's value should update per key press, so it should be capable of saving at any time.