### PR TITLE
The input text will now match the label on first load

### DIFF
--- a/d2l-labs-edit-in-place.js
+++ b/d2l-labs-edit-in-place.js
@@ -137,7 +137,7 @@ class EditInPlace extends LocalizeMixin(LitElement) {
 
 	_enterInputMode() {
 		if (this.readonly) {return;}
-
+		this.shadowRoot.getElementById('Input-Box').value = this.value;
 		this.__inputMode = true;
 		this._focusInput(this.shadowRoot.getElementById('Input-Box'));
 	}


### PR DESCRIPTION
If `value` was supplied on load, the input wouldn't correctly fill with it until the second time the input was displayed. 
Input should now always match the text in the label, if any, when entering input mode.