### PR TITLE
bypassing d2l-input-text validation

### DIFF
--- a/d2l-labs-edit-in-place.js
+++ b/d2l-labs-edit-in-place.js
@@ -121,6 +121,7 @@ class EditInPlace extends LocalizeMixin(LitElement) {
 						class="Input-Box"
 						size="${ifDefined(this.size)}"
 						maxlength="${ifDefined(this.maxlength)}"
+						novalidate
 						placeholder="${this.placeholder}"
 						@keydown="${this._saveValueChange_Keydown}"
 						@change="${this._updateInputTextValue}">


### PR DESCRIPTION
`d2l-input-text` is about to have validation enabled, which will suddenly start checking for min/max/required. Since we're not sure how this will impact places that weren't expecting it, we're disabling it for now.